### PR TITLE
Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zong 3G/4G Router Exploiter                
 
 # Description                   
-This exploit exposes AUTHENTICATING Usernames and Passwords reqiured to login into the ADMIN interface of the router for configuration; to the hacker connected to its local network.                                   
+This exploit exposes AUTHENTICATING Usernames and Passwords required to login into the ADMIN interface of the router for configuration; to the hacker connected to its local network.                                   
 
 # Requirements 
 1. Python 2.7 or higher                           


### PR DESCRIPTION
The same typo also exists in the repo description, which I can't fix via PR.